### PR TITLE
Revert "Bump rustix from 0.36.10 to 0.36.11"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.11"
+version = "0.36.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
+checksum = "2fe885c3a125aa45213b68cc1472a49880cb5923dc23f522ad2791b882228778"
 dependencies = [
  "bitflags",
  "errno",


### PR DESCRIPTION
Reverts lifegpc/pixiv_downloader#545
rustix will cause document error